### PR TITLE
Fix query decoding when opening link

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/browser/Browser.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/browser/Browser.java
@@ -823,7 +823,7 @@ public class Browser {
             modifiedUriBuilder.append(originalUri.getPath());
         }
         if (originalUri.getQuery() != null) {
-            modifiedUriBuilder.append("?").append(originalUri.getQuery());
+            modifiedUriBuilder.append("?").append(originalUri.getEncodedQuery());
         }
         if (originalUri.getFragment() != null) {
             modifiedUriBuilder.append("#").append(originalUri.getFragment());


### PR DESCRIPTION
If the link contains encoded query parameter e.g. other url with query parameters it is automatically decoded, so the query parameters of inner url will become query parameters of the outer one